### PR TITLE
Explicit physics client management

### DIFF
--- a/somo/_version.py
+++ b/somo/_version.py
@@ -7,4 +7,4 @@ https://stackoverflow.com/questions/17583443/what-is-the-correct-way-to-share-pa
 """
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/somo/sm_continuum_manipulator.py
+++ b/somo/sm_continuum_manipulator.py
@@ -37,7 +37,7 @@ def apply_actuation_torques(
         actuationTorques = extended_actuationTorques
 
     for jointId, torque in zip(jointIndices, actuationTorques):
-        jointState = p.getJointState(bodyIndex, jointId, physicsClientId = physicsClient)
+        jointState = p.getJointState(bodyIndex, jointId, physicsClientId=physicsClient)
 
         passive_torque = passiveTorqueFn(jointState, **kwargs)
 
@@ -46,7 +46,7 @@ def apply_actuation_torques(
             jointIndex=jointId,
             controlMode=p.TORQUE_CONTROL,
             force=passive_torque + torque,
-            physicsClientId=physicsClient
+            physicsClientId=physicsClient,
         )
 
 
@@ -57,7 +57,7 @@ def disable_joint_controllers(bodyIndex, jointIndices, forces, physicsClient):
             jointIndex=jointId,
             controlMode=p.VELOCITY_CONTROL,
             force=force,
-            physicsClientId=physicsClient
+            physicsClientId=physicsClient,
         )
 
 
@@ -189,7 +189,7 @@ class SMContinuumManipulator:
             info = p.getJointInfo(
                 bodyUniqueId=self.bodyUniqueId,
                 jointIndex=joint,
-                physicsClientId=self.physics_client ,
+                physicsClientId=self.physics_client,
             )
 
             joint_name = info[1].decode("UTF-8")
@@ -272,7 +272,7 @@ class SMContinuumManipulator:
             self.bodyUniqueId,
             self.flexible_joint_indices,
             self.joint_controller_limit_forces,
-            physicsClient=self.physics_client
+            physicsClient=self.physics_client,
         )
 
         if constrained_base:
@@ -288,7 +288,7 @@ class SMContinuumManipulator:
                 childFramePosition=baseStartPos,
                 parentFrameOrientation=p.getQuaternionFromEuler([0, 0, 0]),
                 childFrameOrientation=baseStartOrn,
-                physicsClientId = self.physics_client
+                physicsClientId=self.physics_client,
             )
 
         else:
@@ -393,7 +393,9 @@ class SMContinuumManipulator:
             extended_actuation_torque = [act_torque for x in range(len(joint_indices))]
 
             for jointId, torque in zip(joint_indices, extended_actuation_torque):
-                jointState = p.getJointState(self.bodyUniqueId, jointId, self.physics_client)
+                jointState = p.getJointState(
+                    self.bodyUniqueId, jointId, self.physics_client
+                )
                 jointPos = jointState[0]
 
                 passive_torque = -spring_const * (jointPos - offset)
@@ -403,7 +405,7 @@ class SMContinuumManipulator:
                     jointIndex=jointId,
                     controlMode=p.TORQUE_CONTROL,
                     force=passive_torque + torque,
-                    physicsClientId = self.physics_client
+                    physicsClientId=self.physics_client,
                 )
 
             addressed_actuator_axis_pairs.append((actuator_nr, axis_nr))
@@ -476,7 +478,10 @@ class SMContinuumManipulator:
             self.joint_controller_limit_forces[index] = limit_force
 
         disable_joint_controllers(
-            bodyIndex=self.bodyUniqueId, jointIndices=jointIds, forces=limit_forces, physicsClient = self.physics_client
+            bodyIndex=self.bodyUniqueId,
+            jointIndices=jointIds,
+            forces=limit_forces,
+            physicsClient=self.physics_client,
         )
 
     def set_contact_property(self, property_dict):
@@ -487,7 +492,7 @@ class SMContinuumManipulator:
                 self.bodyUniqueId,
                 i,
                 **property_dict,
-                physicsClientId=self.physics_client
+                physicsClientId=self.physics_client,
             )
 
     def get_backbone_position(self, s):
@@ -500,7 +505,11 @@ class SMContinuumManipulator:
             i += 1
 
         # todo: make more precise; don't just return the center of the link into which the arc length end falls
-        linkState = p.getLinkState(bodyUniqueId=self.bodyUniqueId, linkIndex=i, physicsClientId = self.physics_client )
+        linkState = p.getLinkState(
+            bodyUniqueId=self.bodyUniqueId,
+            linkIndex=i,
+            physicsClientId=self.physics_client,
+        )
         link_pos = linkState[0]
 
         return link_pos
@@ -509,7 +518,11 @@ class SMContinuumManipulator:
     def get_backbone_positions(self):
         positions = []
         for ind in range(len(self.linkId_to_arcLength)):
-            linkState = p.getLinkState(bodyUniqueId=self.bodyUniqueId, linkIndex=ind, physicsClientId = self.physics_client)
+            linkState = p.getLinkState(
+                bodyUniqueId=self.bodyUniqueId,
+                linkIndex=ind,
+                physicsClientId=self.physics_client,
+            )
             link_pos = linkState[0]
             positions.append(link_pos)
         return positions
@@ -518,7 +531,9 @@ class SMContinuumManipulator:
     def get_backbone_angles(self):
         angles = []
         for ind in self.flexible_joint_indices:
-            jointState = p.getJointState(self.bodyUniqueId, ind, physicsClientId = self.physics_client)
+            jointState = p.getJointState(
+                self.bodyUniqueId, ind, physicsClientId=self.physics_client
+            )
             jointPos = jointState[0]
             angles.append(jointPos)
         return angles
@@ -527,7 +542,9 @@ class SMContinuumManipulator:
         print("WARNING: offset by a constant factor")  # todo: fix this
         curvatures = []
         for ind in self.flexible_joint_indices:
-            jointState = p.getJointState(self.bodyUniqueId, ind, physicsClientId = self.physics_client)
+            jointState = p.getJointState(
+                self.bodyUniqueId, ind, physicsClientId=self.physics_client
+            )
             segment_length = 1  # TODO: add correct segment length
             angle = jointState[0]
             curvature = np.cos(angle / 2) / (segment_length / 2)
@@ -540,7 +557,10 @@ class SMContinuumManipulator:
         velocities = []
         for ind in range(len(self.linkId_to_arcLength)):
             linkState = p.getLinkState(
-                bodyUniqueId=self.bodyUniqueId, linkIndex=ind, computeLinkVelocity=1, physicsClientId = self.physics_client
+                bodyUniqueId=self.bodyUniqueId,
+                linkIndex=ind,
+                computeLinkVelocity=1,
+                physicsClientId=self.physics_client,
             )
             link_pos = linkState[0]
             link_vel = linkState[6]

--- a/somo/sm_continuum_manipulator.py
+++ b/somo/sm_continuum_manipulator.py
@@ -17,7 +17,7 @@ import pdb
 
 # todo: consider removing this? not sure it will be used; depends on whether non-linear joint-angle vs restoring force relationship will be needed
 def apply_actuation_torques(
-    bodyIndex, jointIndices, actuationTorques, passiveTorqueFn, **kwargs
+    bodyIndex, jointIndices, actuationTorques, passiveTorqueFn, physicsClient, **kwargs
 ):
     try:  # xx todo: do this better with asserts
         actuationTorques = float(
@@ -37,7 +37,7 @@ def apply_actuation_torques(
         actuationTorques = extended_actuationTorques
 
     for jointId, torque in zip(jointIndices, actuationTorques):
-        jointState = p.getJointState(bodyIndex, jointId)
+        jointState = p.getJointState(bodyIndex, jointId, physicsClientId = physicsClient)
 
         passive_torque = passiveTorqueFn(jointState, **kwargs)
 
@@ -46,16 +46,18 @@ def apply_actuation_torques(
             jointIndex=jointId,
             controlMode=p.TORQUE_CONTROL,
             force=passive_torque + torque,
+            physicsClientId=physicsClient
         )
 
 
-def disable_joint_controllers(bodyIndex, jointIndices, forces):
+def disable_joint_controllers(bodyIndex, jointIndices, forces, physicsClient):
     for jointId, force in zip(jointIndices, forces):
         p.setJointMotorControl2(
             bodyIndex=bodyIndex,
             jointIndex=jointId,
             controlMode=p.VELOCITY_CONTROL,
             force=force,
+            physicsClientId=physicsClient
         )
 
 
@@ -120,6 +122,7 @@ class SMContinuumManipulator:
         # todo: give the option to pass in the torque function?
 
         self.instantiated = False
+        self.physics_client = None  # if the manipulator is not loaded to pybullet, the physics client is None.
 
     def load_to_pybullet(
         self, baseStartPos, baseStartOrn, baseConstraint, physicsClient, flags=None
@@ -127,6 +130,8 @@ class SMContinuumManipulator:
         """adds the manipulator to the simulation defined in physicsCient. if fixedBase is 1 or True, a constraint
         is added that holds the base in place"""
         # todo: documentation
+
+        self.physics_client = physicsClient
 
         assert baseConstraint in [
             "constrained",
@@ -169,14 +174,14 @@ class SMContinuumManipulator:
             self.manipulator_definition.urdf_filename,
             baseStartPos,
             baseStartOrn,
-            physicsClientId=physicsClient,
+            physicsClientId=self.physics_client,
             useFixedBase=static_base,
             flags=all_flags,
         )
         # pdb.set_trace()
 
         num_joints = p.getNumJoints(
-            bodyUniqueId=self.bodyUniqueId, physicsClientId=physicsClient
+            bodyUniqueId=self.bodyUniqueId, physicsClientId=self.physics_client
         )
         # todo: comment to explain logic
         for joint in range(num_joints):
@@ -184,7 +189,7 @@ class SMContinuumManipulator:
             info = p.getJointInfo(
                 bodyUniqueId=self.bodyUniqueId,
                 jointIndex=joint,
-                physicsClientId=physicsClient,
+                physicsClientId=self.physics_client ,
             )
 
             joint_name = info[1].decode("UTF-8")
@@ -267,6 +272,7 @@ class SMContinuumManipulator:
             self.bodyUniqueId,
             self.flexible_joint_indices,
             self.joint_controller_limit_forces,
+            physicsClient=self.physics_client
         )
 
         if constrained_base:
@@ -282,6 +288,7 @@ class SMContinuumManipulator:
                 childFramePosition=baseStartPos,
                 parentFrameOrientation=p.getQuaternionFromEuler([0, 0, 0]),
                 childFrameOrientation=baseStartOrn,
+                physicsClientId = self.physics_client
             )
 
         else:
@@ -386,7 +393,7 @@ class SMContinuumManipulator:
             extended_actuation_torque = [act_torque for x in range(len(joint_indices))]
 
             for jointId, torque in zip(joint_indices, extended_actuation_torque):
-                jointState = p.getJointState(self.bodyUniqueId, jointId)
+                jointState = p.getJointState(self.bodyUniqueId, jointId, self.physics_client)
                 jointPos = jointState[0]
 
                 passive_torque = -spring_const * (jointPos - offset)
@@ -396,6 +403,7 @@ class SMContinuumManipulator:
                     jointIndex=jointId,
                     controlMode=p.TORQUE_CONTROL,
                     force=passive_torque + torque,
+                    physicsClientId = self.physics_client
                 )
 
             addressed_actuator_axis_pairs.append((actuator_nr, axis_nr))
@@ -436,7 +444,7 @@ class SMContinuumManipulator:
 
     def update_joint_control_limitForce(
         self, jointIds, limit_forces
-    ):  # xx todo: consider renaming
+    ):  # xx todo: consider renaming; add physicsClientID
 
         assert (
             False
@@ -468,7 +476,7 @@ class SMContinuumManipulator:
             self.joint_controller_limit_forces[index] = limit_force
 
         disable_joint_controllers(
-            bodyIndex=self.bodyUniqueId, jointIndices=jointIds, forces=limit_forces
+            bodyIndex=self.bodyUniqueId, jointIndices=jointIds, forces=limit_forces, physicsClient = self.physics_client
         )
 
     def set_contact_property(self, property_dict):
@@ -479,6 +487,7 @@ class SMContinuumManipulator:
                 self.bodyUniqueId,
                 i,
                 **property_dict,
+                physicsClientId=self.physics_client
             )
 
     def get_backbone_position(self, s):
@@ -491,7 +500,7 @@ class SMContinuumManipulator:
             i += 1
 
         # todo: make more precise; don't just return the center of the link into which the arc length end falls
-        linkState = p.getLinkState(bodyUniqueId=self.bodyUniqueId, linkIndex=i)
+        linkState = p.getLinkState(bodyUniqueId=self.bodyUniqueId, linkIndex=i, physicsClientId = self.physics_client )
         link_pos = linkState[0]
 
         return link_pos
@@ -500,7 +509,7 @@ class SMContinuumManipulator:
     def get_backbone_positions(self):
         positions = []
         for ind in range(len(self.linkId_to_arcLength)):
-            linkState = p.getLinkState(bodyUniqueId=self.bodyUniqueId, linkIndex=ind)
+            linkState = p.getLinkState(bodyUniqueId=self.bodyUniqueId, linkIndex=ind, physicsClientId = self.physics_client)
             link_pos = linkState[0]
             positions.append(link_pos)
         return positions
@@ -509,7 +518,7 @@ class SMContinuumManipulator:
     def get_backbone_angles(self):
         angles = []
         for ind in self.flexible_joint_indices:
-            jointState = p.getJointState(self.bodyUniqueId, ind)
+            jointState = p.getJointState(self.bodyUniqueId, ind, physicsClientId = self.physics_client)
             jointPos = jointState[0]
             angles.append(jointPos)
         return angles
@@ -518,7 +527,7 @@ class SMContinuumManipulator:
         print("WARNING: offset by a constant factor")  # todo: fix this
         curvatures = []
         for ind in self.flexible_joint_indices:
-            jointState = p.getJointState(self.bodyUniqueId, ind)
+            jointState = p.getJointState(self.bodyUniqueId, ind, physicsClientId = self.physics_client)
             segment_length = 1  # TODO: add correct segment length
             angle = jointState[0]
             curvature = np.cos(angle / 2) / (segment_length / 2)
@@ -531,7 +540,7 @@ class SMContinuumManipulator:
         velocities = []
         for ind in range(len(self.linkId_to_arcLength)):
             linkState = p.getLinkState(
-                bodyUniqueId=self.bodyUniqueId, linkIndex=ind, computeLinkVelocity=1
+                bodyUniqueId=self.bodyUniqueId, linkIndex=ind, computeLinkVelocity=1, physicsClientId = self.physics_client
             )
             link_pos = linkState[0]
             link_vel = linkState[6]


### PR DESCRIPTION
adds explicit management of the physics client for each continuum manipulator object, such that it is always clear which manipulator is addresses/queried. this is a necessary feature to enable running multiple SoMoGym environments concurrently. 